### PR TITLE
chore: use createOrUpdateFileContents

### DIFF
--- a/.github/workflows/scripts/register_buildpack/index.js
+++ b/.github/workflows/scripts/register_buildpack/index.js
@@ -108,7 +108,7 @@ async function retrieveOwners({github, context}, buildpackInfo, owner, repo, ver
             const buff = Buffer.from(JSON.stringify(content), 'utf-8');
             registryOwners = buff.toString('utf-8')
 
-            await github.repos.createOrUpdateFile({
+            await github.repos.createOrUpdateFileContents({
                 owner,
                 repo,
                 path: `${version}/${buildpackInfo.ns}.json`,

--- a/.github/workflows/scripts/register_buildpack/test/index.test.js
+++ b/.github/workflows/scripts/register_buildpack/test/index.test.js
@@ -163,10 +163,10 @@ describe('index', function () {
 
         it('should create the owners json file when missing', async () => {
             const getContentStub = sandbox.stub().throws({status: 404})
-            const createOrUpdateFileStub = sandbox.stub()
+            const createOrUpdateFileContentsStub = sandbox.stub()
 
             octokit.repos.getContent = getContentStub
-            octokit.repos.createOrUpdateFile = createOrUpdateFileStub
+            octokit.repos.createOrUpdateFileContents = createOrUpdateFileContentsStub
 
             const result = await Registry.retrieveOwners(
                 {github: octokit, context: issueContext},
@@ -178,8 +178,8 @@ describe('index', function () {
 
             expect(getContentStub.callCount).to.equal(1)
             expect(getContentStub.firstCall.args[0]).to.deep.equal(expectedGetContentArgs)
-            expect(createOrUpdateFileStub.callCount).to.equal(1)
-            expect(createOrUpdateFileStub.firstCall.args[0]).to.deep.equal(expectedCreateOrUpdateFileArgs)
+            expect(createOrUpdateFileContentsStub.callCount).to.equal(1)
+            expect(createOrUpdateFileContentsStub.firstCall.args[0]).to.deep.equal(expectedCreateOrUpdateFileArgs)
             expect(result).to.equal('{"owners":[{"id":11111,"type":"github_user"}]}')
         })
 


### PR DESCRIPTION
This PR addresses an API name change warning for the Nodejs `octokit` lib:
```
 octokit.repos.createOrUpdateFile() has been renamed to octokit.repos.createOrUpdateFileContents()
```