### PR TITLE
Add and Yank Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-buildpack.md
+++ b/.github/ISSUE_TEMPLATE/add-buildpack.md
@@ -1,0 +1,12 @@
+---
+name: Add Buildpack
+about: Propose the addition of a buildpack to the registry index
+title: ADD {BUILDPACK_ID}@{VERSION}
+labels: ''
+assignees: ''
+
+---
+
+id = "{BUILDPACK_ID}"
+version = "{VERSION}"
+addr = "{DOCKER URI}@{DIGEST}"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/yank-buildpack.md
+++ b/.github/ISSUE_TEMPLATE/yank-buildpack.md
@@ -1,0 +1,11 @@
+---
+name: Yank Buildpack
+about: Propose the removal of a buildpack from the registry index
+title: YANK {BUILDPACK_ID}@{VERSION}
+labels: ''
+assignees: ''
+
+---
+
+id = "{BUILDPACK_ID}"
+version = "{VERSION}"


### PR DESCRIPTION
In order to facilitate manual issue creation and to act as a template for other automations, the registry should have issue templates with the proper payloads.