### PR TITLE
Add a check to see if a version already exists before registering it

### DIFF
--- a/.github/workflows/scripts/register_buildpack/index.js
+++ b/.github/workflows/scripts/register_buildpack/index.js
@@ -183,6 +183,11 @@ async function indexRegistryForBuildpack({github, context}, buildpackInfo, owner
 
         let buff = new Buffer.from(data.content, 'base64')
         let fileContent = buff.toString('utf-8').trimEnd()
+
+        if (await versionAlreadyExists(fileContent, buildpackInfo)) {
+            throw new Error('duplicate version')
+        }
+
         fileContent = fileContent + "\n" + JSON.stringify(buildpackInfo)
 
         await createOrUpdateFileContents(
@@ -229,10 +234,20 @@ async function closeIssue({github, context}, owner, repo, labels, comment = '') 
     })
 }
 
+async function versionAlreadyExists(existingVersions, buildpackInfo) {
+    return existingVersions.split("\n").some((element, _) => {
+        if (element !== "") {
+            let existingVersion = JSON.parse(element)
+            return existingVersion.version === buildpackInfo.version
+        }
+    })
+}
+
 module.exports = {
     validateIssue,
     retrieveOwners,
     isAuthorized,
     indexRegistryForBuildpack,
-    closeIssue
+    closeIssue,
+    versionAlreadyExists
 }

--- a/.github/workflows/scripts/register_buildpack/test/index.test.js
+++ b/.github/workflows/scripts/register_buildpack/test/index.test.js
@@ -669,6 +669,23 @@ describe('index', function () {
             }
         })
     })
+
+    describe('#versionAlreadyExists', () => {
+        it('should return false if the version does not exist', async () => {
+            let v = await Registry.versionAlreadyExists( '{"version":"0.1.0"}', {"version":"0.2.0"})
+            expect(v).to.be.false
+        })
+
+        it('should return true if the version exists', async () => {
+            let v = await Registry.versionAlreadyExists( '{"version":"0.1.0"}', {"version":"0.1.0"})
+            expect(v).to.be.true
+        })
+
+        it('should return false if there are no existing versions', async () => {
+            let v = await Registry.versionAlreadyExists('', {"version":"0.1.0"})
+            expect(v).to.be.false
+        })
+    })
 });
 
 // HELPER FUNCTIONS


### PR DESCRIPTION
This prevents a buildpack from re-registering the a version that already exists.