### PR TITLE
Add a list of restricted namespaces

### DIFF
--- a/.github/workflows/scripts/register_buildpack/index.js
+++ b/.github/workflows/scripts/register_buildpack/index.js
@@ -2,6 +2,26 @@ const Path = require('path');
 const Schema = require('validate')
 const Toml = require('toml')
 
+const restrictedNamespaces = [
+    "example",
+    "examples",
+    "official",
+    "buildpack",
+    "buildpacks",
+    "buildpacksio",
+    "buildpackio",
+    "buildpacks-io",
+    "buildpack-io",
+    "buildpacks.io",
+    "buildpack.io",
+    "pack",
+    "cnb",
+    "cnbs",
+    "cncf",
+    "cncf-cnb",
+    "cncf-cnbs"
+]
+
 const bodySchema = new Schema({
     id: {
         type: String,
@@ -74,13 +94,19 @@ function validateIssue({context}) {
         throw new Error(`${errors}`)
     }
 
-    return {
+    buildpackInfo = {
         ns: tomlData.id.split("/")[0],
         name: tomlData.id.split("/")[1],
         version: tomlData.version,
         yanked: false,
         addr: tomlData.addr
     }
+
+    if (restrictedNamespaces.includes(buildpackInfo.ns)) {
+        throw new Error(`"${buildpackInfo.ns}" is a restricted namespace`)
+    }
+
+    return buildpackInfo
 }
 
 async function retrieveOwners({github, context}, buildpackInfo, owner, repo, version) {

--- a/.github/workflows/scripts/register_buildpack/test/index.test.js
+++ b/.github/workflows/scripts/register_buildpack/test/index.test.js
@@ -125,6 +125,25 @@ describe('index', function () {
 
             expect(() => Registry.validateIssue({context: badAddrIssueContext})).to.throw('Error: invalid addr')
         })
+
+        it('should throw error if namespace is restricted', () => {
+            const context = {
+                payload: {
+                    sender: {
+                        id: 11111,
+                        login: 'elbandito'
+                    },
+                    issue: {
+                        number: 3117,
+                        title: 'ADD example/java@0.0.0',
+                        body: 'id = "example/java"\n' +
+                            'version = "0.0.0"\n' +
+                            'addr = "gcr.io/heroku/java@sha256:9d88250dfd77dbf5a535f1358c6a05dc2c0d3a22defbdcd72bb8f5e24b84e21d"'
+                    }
+                }
+            }
+            expect(() => Registry.validateIssue({context: context})).to.throw('"example" is a restricted namespace')
+        })
     });
 
     describe('#retrieveOwners', () => {


### PR DESCRIPTION
Buildpack registration should fail if any of the following namespaces are used:

* `example`
* `examples`
* `sample`
* `samples`
* `official`
* `buildpack`
* `buildpacks`
* `buildpacksio`
* `buildpackio`
* `buildpacks-io`
* `buildpack-io`
* `buildpacks.io`
* `buildpack.io`
* `pack`
* `cnb`
* `cnbs`
* `cncf`
* `cncf-cnb`
* `cncf-cnbs`