### PR TITLE
Add 'sample(s)' to restricted namespaces

### DIFF
--- a/.github/workflows/scripts/register_buildpack/index.js
+++ b/.github/workflows/scripts/register_buildpack/index.js
@@ -5,6 +5,8 @@ const Toml = require('toml')
 const restrictedNamespaces = [
     "example",
     "examples",
+    "sample",
+    "samples",
     "official",
     "buildpack",
     "buildpacks",


### PR DESCRIPTION
Restrict `sample` and `samples`