### PR TITLE
Add a message when the registration is successful

### DIFF
--- a/.github/workflows/register-buildpack.yml
+++ b/.github/workflows/register-buildpack.yml
@@ -113,6 +113,8 @@ jobs:
           script: |
             const path = require('path')
             const scripts = require(path.resolve(`${process.env.SCRIPTS_PATH}/index.js`))
+            const comment = `
+            ✅ Successfully registered the buildpack`
             try {
               await scripts.closeIssue(
                 {github, context},


### PR DESCRIPTION
This helps make it clear that the registration was successful. Without it, the closed issue only shows a 🚫 symbol, which at first glance makes it look like something went wrong.